### PR TITLE
feat: run install-node.sh during docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="hitalos <hitalos@gmail.com>"
 
 # Download and install NodeJS
 ADD install-node.sh /usr/sbin/install-node.sh
+RUN /usr/sbin/install-node.sh
 
 WORKDIR /var/www
 CMD php ./artisan serve --port=80 --host=0.0.0.0


### PR DESCRIPTION
Add execution instruction for the Node installation shell script to setup node environment variables.