### PR TITLE
chore: remove default artisan serve start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,3 @@ LABEL maintainer="hitalos <hitalos@gmail.com>"
 ADD install-node.sh /usr/sbin/install-node.sh
 RUN /usr/sbin/install-node.sh
 
-WORKDIR /var/www
-CMD php ./artisan serve --port=80 --host=0.0.0.0
-EXPOSE 80
-HEALTHCHECK --interval=1m CMD curl -f http://localhost/ || exit 1


### PR DESCRIPTION
Remove built-in artisan serve from Dockerfile to allow specifying custom container startup entrypoints.