### PR TITLE
chore: remove build dependencies block from node installer

### DIFF
--- a/install-node.sh
+++ b/install-node.sh
@@ -10,6 +10,3 @@ curl -s -0 -L npmjs.org/install.sh | sh
 
 # Install Yarn
 npm i -g yarn
-
-# Install build dependencies
-apk add autoconf automake g++ gcc libpng-dev libtool make nasm python


### PR DESCRIPTION
Clean up build dependencies installation from the Node setup script.