### PR TITLE
feat: add build dependencies to apk packages in node installation

### DIFF
--- a/install-node.sh
+++ b/install-node.sh
@@ -10,3 +10,5 @@ curl -s -0 -L npmjs.org/install.sh | sh
 # Install Yarn
 npm i -g yarn
 
+# Install build dependencies
+apk add autoconf automake g++ gcc libpng-dev libtool make nasm python


### PR DESCRIPTION
Install build tools (autoconf, automake, gcc, g++, libpng-dev, libtool, make, nasm, python) during the node.sh setup step to support compiling native addons.